### PR TITLE
update furnitureMenu.lua

### DIFF
--- a/client/MenuSetup/furnitureMenu.lua
+++ b/client/MenuSetup/furnitureMenu.lua
@@ -350,5 +350,5 @@ RegisterNetEvent('bcc-housing:SellOwnedFurnMenu', function(furnTable)
 end)
 
 RegisterNetEvent('bcc-housing:ClientCloseAllMenus', function()
-    MenuData.CloseAll()
+    VORPMenu.CloseAll()
 end)


### PR DESCRIPTION
- this fixes the menu to close when players try to sell furniture from their house.. furniture Menu never close after sell  and they could sell unlimited times that furniture...